### PR TITLE
Declare return type of healthcheck

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -21,8 +21,8 @@ impl Server {
         warp::serve(routes).run(addr)
     }
 
-    fn healthcheck(&self) -> BoxedFilter<(impl Reply,)> {
-        warp::path("healthcheck").map(|| "ok").boxed()
+    fn healthcheck(&self) -> BoxedFilter<(String,)> {
+        warp::path("healthcheck").map(|| "ok".into()).boxed()
     }
 
     fn api(&self) -> BoxedFilter<(impl Reply,)> {


### PR DESCRIPTION
The `BoxedFilter` struct's purpose is not only to ease returning `Filter`s from other functions but also to ease naming the type.
So at first, utilize `BoxedFilter` to declare the return type of healthcheck.