### PR TITLE
on_conflict do_nothing when create user

### DIFF
--- a/src/domain/model/user.rs
+++ b/src/domain/model/user.rs
@@ -20,6 +20,6 @@ pub struct NewUser<'a> {
 }
 
 pub trait IUserRepository {
-    fn create<'a>(&self, sub_id: &'a str) -> Result<User, ServiceError>;
+    fn create<'a>(&self, sub_id: &'a str) -> Result<usize, ServiceError>;
     fn find_by_sub_id<'a>(&self, sub_id: &'a str) -> Result<Option<User>, ServiceError>;
 }

--- a/src/domain/service/user_service.rs
+++ b/src/domain/service/user_service.rs
@@ -18,7 +18,7 @@ where
         UserService { user_repository }
     }
 
-    pub fn create<'a>(&self, sub_id: &'a str) -> Result<User, ServiceError> {
+    pub fn create<'a>(&self, sub_id: &'a str) -> Result<usize, ServiceError> {
         self.user_repository.create(sub_id)
     }
 }

--- a/src/infra/user_repository.rs
+++ b/src/infra/user_repository.rs
@@ -16,7 +16,7 @@ impl UserRepository {
 }
 
 impl IUserRepository for UserRepository {
-    fn create<'a>(&self, sub_id: &'a str) -> Result<User, ServiceError> {
+    fn create<'a>(&self, sub_id: &'a str) -> Result<usize, ServiceError> {
         use crate::schema::users;
 
         let new_user = NewUser { sub_id };
@@ -25,7 +25,7 @@ impl IUserRepository for UserRepository {
             .values(&new_user)
             .on_conflict(users::sub_id)
             .do_nothing()
-            .get_result(&*self.conn.lock().unwrap())
+            .execute(&*self.conn.lock().unwrap())
             .map_err(ServiceError::DbQueryFailed)
     }
 

--- a/src/infra/user_repository.rs
+++ b/src/infra/user_repository.rs
@@ -23,6 +23,8 @@ impl IUserRepository for UserRepository {
 
         diesel::insert_into(users::table)
             .values(&new_user)
+            .on_conflict(users::sub_id)
+            .do_nothing()
             .get_result(&*self.conn.lock().unwrap())
             .map_err(ServiceError::DbQueryFailed)
     }


### PR DESCRIPTION
`POST /users` should be treated without any effect if a requested `sub_id` already exists on the DB, since `users.sub_id` is `UNIQUE`.

https://docs.rs/diesel/1.4.5/diesel/query_builder/struct.InsertStatement.html#method.on_conflict